### PR TITLE
詳細からマップアプリに遷移後、該当の地点にピンを配置するようにNSURLを変更

### DIFF
--- a/OmosanMaps/Sources/Place/PlaceDetailViewController.swift
+++ b/OmosanMaps/Sources/Place/PlaceDetailViewController.swift
@@ -110,7 +110,7 @@ private extension PlaceDetailViewController {
     private func openInMap() {
         guard
             let placemark = self.placemark,
-            let url = NSURL(string: "https://maps.apple.com/?ll=\(placemark.coordinate.latitude),\(placemark.coordinate.longitude)")
+            let url = NSURL(string: "https://maps.apple.com/?ll=\(placemark.coordinate.latitude),\(placemark.coordinate.longitude)&q=\(placemark.name.encodingToURIRepresentation())")
         else {
             return
         }


### PR DESCRIPTION
Map Link のクエリに`ll`でLatLngを指定し、さらに`q`で地点の名前を指定すると、
ピンが配置されるようになる

https://developer.apple.com/library/ios/featuredarticles/iPhoneURLScheme_Reference/MapLinks/MapLinks.html
